### PR TITLE
bug fixes (--no-cache, vicon launch file, dinova1 and dinova2 export)

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -39,4 +39,4 @@ if [ -z "$INSTALL" ]; then
 fi
 
 cd ..
-sudo docker build -t compliant_control_${ROS}_${INSTALL} -f docker/Dockerfile --build-arg ROS=${ROS} --build-arg INSTALL=${INSTALL} .
+sudo docker build --no-cache -t compliant_control_${ROS}_${INSTALL} -f docker/Dockerfile --build-arg ROS=${ROS} --build-arg INSTALL=${INSTALL} --privileged .

--- a/export_dinova1
+++ b/export_dinova1
@@ -1,0 +1,22 @@
+#!/bin/bash
+# initialize ROS MASTER URI and ROS_IP for dinova1 (dingo 1 + kinova 1)
+# export ROS_MASTER_URI=http://192.168.0.121:11311
+
+DEVICE_IP=""
+IPs=$(hostname -I)
+for IP in $IPs
+do
+    if [[ $IP == *"192.168.0."* ]]; then
+        DEVICE_IP=$IP;
+        break;
+    fi
+done
+
+if [ -z "$DEVICE_IP" ]; then
+    echo Device is not in expected newtork.;
+else
+    export ROS_MASTER_URI=http://192.168.0.121:11311;
+    export ROS_IP="${DEVICE_IP}";
+    echo ROS_MASTER_URI: ${ROS_MASTER_URI}
+    echo ROS_IP: ${ROS_IP}
+fi

--- a/export_dinova2
+++ b/export_dinova2
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-# export ROS_MASTER_URI=http://192.168.0.121:11311
+# initialize ROS MASTER URI and ROS_IP for dinova2 (dingo 2 + kinova 2)
+# export ROS_MASTER_URI=http://192.168.0.122:11311
 
 DEVICE_IP=""
 IPs=$(hostname -I)
@@ -15,7 +15,7 @@ done
 if [ -z "$DEVICE_IP" ]; then
     echo Device is not in expected newtork.;
 else
-    export ROS_MASTER_URI=http://192.168.0.121:11311;
+    export ROS_MASTER_URI=http://192.168.0.122:11311;
     export ROS_IP="${DEVICE_IP}";
     echo ROS_MASTER_URI: ${ROS_MASTER_URI}
     echo ROS_IP: ${ROS_IP}

--- a/ros/noetic/src/launcher/launch/vicon_node.launch
+++ b/ros/noetic/src/launcher/launch/vicon_node.launch
@@ -1,0 +1,21 @@
+<launch>
+  <arg name="robot_name" default="dingo2"/> 
+
+  <!-- Launch the Vicon bridge to get pose readings.
+       Since there may be many robots around, we forward objects individually.
+       If you want to add an additional objectd (e.g. an obstacle), you need
+       to add a new element to each of the arrays below.
+
+       See also https://github.com/tud-amr/vicon-bridge for more information.
+       
+       Possible arguments for robot_name are: "dingo1" or "dingo2"
+  -->
+  <include file="$(find vicon_bridge)/launch/vicon.launch">
+    <arg name="object_names" default="[$(arg robot_name)]"/>
+    <arg name="object_msg_types" default="[geometry_msgs/PoseStamped]"/>
+    <arg name="object_frame_ids" default="[map]"/>
+    <arg name="object_publish_topics" default="[/vicon]"/>
+    <arg name="object_frequency_divider" default="[1]"/>
+  </include>
+
+</launch>


### PR DESCRIPTION
small changes to:
build: add --no-cache
added a vicon launch file that calls the vicon bridge in launcher. robot_name should be provided as argument (default = dingo2)
dinova1 and dinova2as export files.

Vicon node is checked in the lab. 
@Jelmerdw, feel free to merge/adapt as you would like. 